### PR TITLE
Steal Ruby 2.6 binding#source_location fix from pry

### DIFF
--- a/lib/autoloaded/autoloader.rb
+++ b/lib/autoloaded/autoloader.rb
@@ -263,7 +263,11 @@ module Autoloaded
     end
 
     def host_source_filename
-      host_eval '::File.expand_path __FILE__'
+      if host_binding.respond_to?(:source_location)
+        host_eval "::File.expand_path '#{host_binding.source_location.first}'"
+      else
+        host_eval '::File.expand_path __FILE__'
+      end
     end
 
     def host_source_location

--- a/lib/autoloaded/autoloader.rb
+++ b/lib/autoloaded/autoloader.rb
@@ -267,7 +267,11 @@ module Autoloaded
     end
 
     def host_source_location
-      host_eval('[__FILE__, __LINE__]').collect(&:to_s).join ':'
+      if host_binding.respond_to?(:source_location)
+        host_binding.source_location
+      else
+        host_eval('[__FILE__, __LINE__]')
+      end.collect(&:to_s).join ':'
     end
 
   end


### PR DESCRIPTION
Fixes issue #13 

Copied from https://github.com/alanbrent/pry/commit/dc2149ee31afa99d33889d74fc630c638ecb5af2

Both pry and autoloaded are MIT licensed, so I'm assuming its OK.